### PR TITLE
Updated citation for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,21 @@ files. These can be computed from MOTChallenge detections using
 If you find this repo useful in your research, please consider citing the following papers:
 
     @inproceedings{Wojke2017simple,
+      title={Simple Online and Realtime Tracking with a Deep Association Metric},
       author={Wojke, Nicolai and Bewley, Alex and Paulus, Dietrich},
       booktitle={2017 IEEE International Conference on Image Processing (ICIP)},
-      title={Simple Online and Realtime Tracking with a Deep Association Metric},
       year={2017},
       pages={3645--3649},
+      organization={IEEE}
       doi={10.1109/ICIP.2017.8296962}
     }
 
-    @inproceedings{Bewley2016_sort,
-      author={Bewley, Alex and Ge, Zongyuan and Ott, Lionel and Ramos, Fabio and Upcroft, Ben},
-      booktitle={2016 IEEE International Conference on Image Processing (ICIP)},
-      title={Simple Online and Realtime Tracking},
-      year={2016},
-      pages={3464-3468},
-      doi={10.1109/ICIP.2016.7533003}
+    @inproceedings{Wojke2018deep,
+      title={Deep Cosine Metric Learning for Person Re-identification},
+      author={Wojke, Nicolai and Bewley, Alex},
+      booktitle={2018 IEEE Winter Conference on Applications of Computer Vision (WACV)},
+      year={2018},
+      pages={748--756},
+      organization={IEEE}
+      doi={10.1109/WACV.2018.00087}
     }


### PR DESCRIPTION
Replaced SORT citation with the WACV 2018 to represent more related training code used for the models in this repo.
Reordered bibtex elements for consistency.