### PR TITLE
Fixed the display flag

### DIFF
--- a/deep_sort_app.py
+++ b/deep_sort_app.py
@@ -212,6 +212,12 @@ def run(sequence_dir, detection_file, output_file, min_confidence,
             row[0], row[1], row[2], row[3], row[4], row[5]),file=f)
 
 
+def bool_string(input_string):
+    if input_string not in {'True','False'}:
+        raise ValueError('Please Enter a valid Ture/False choice')
+    else:
+        return (input_string == 'True')
+
 def parse_args():
     """ Parse command line arguments.
     """
@@ -245,7 +251,7 @@ def parse_args():
         "gallery. If None, no budget is enforced.", type=int, default=None)
     parser.add_argument(
         "--display", help="Show intermediate tracking results",
-        default=True, type=bool)
+        default=True, type=bool_string)
     return parser.parse_args()
 
 

--- a/deep_sort_app.py
+++ b/deep_sort_app.py
@@ -213,10 +213,10 @@ def run(sequence_dir, detection_file, output_file, min_confidence,
 
 
 def bool_string(input_string):
-    if input_string not in {'True','False'}:
-        raise ValueError('Please Enter a valid Ture/False choice')
+    if input_string not in {"True","False"}:
+        raise ValueError("Please Enter a valid Ture/False choice")
     else:
-        return (input_string == 'True')
+        return (input_string == "True")
 
 def parse_args():
     """ Parse command line arguments.


### PR DESCRIPTION
(Refer Issue #49) labelled as a bug. This pull request resolves the issue by fixing the bug.
If the type in Argument Parser is specified as bool, it expects a boolean value but the parser gives it a string.
bool('False') is True when False is given as a string input. Therefore, the display flag is always True.
With display set as true always, we cannot run the code without an X-server or without calling the run function with a hard-coded false value.