### PR TITLE
Update linear_assignment.py

### DIFF
--- a/deep_sort/linear_assignment.py
+++ b/deep_sort/linear_assignment.py
@@ -1,7 +1,9 @@
 # vim: expandtab:ts=4:sw=4
 from __future__ import absolute_import
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment as linear_assignment
+#deprecated sklearn function
+#from sklearn.utils.linear_assignment_ import linear_assignment
 from . import kalman_filter
 
 


### PR DESCRIPTION
The function "from sklearn.utils.linear_assignment_ import linear_assignment" is deprecated. Can be replaced by scipy