### PR TITLE
Fix bbox bottom right corner calculation

### DIFF
--- a/deep_sort/iou_matching.py
+++ b/deep_sort/iou_matching.py
@@ -23,7 +23,7 @@ def iou(bbox, candidates):
         occluded by the candidate.
 
     """
-    bbox_tl, bbox_br = bbox[:2], bbox[:2] + bbox[2:]
+    bbox_tl, bbox_br = bbox[:2], bbox[:2] + bbox[2:] - 1
     candidates_tl = candidates[:, :2]
     candidates_br = candidates[:, :2] + candidates[:, 2:]
 

--- a/tools/generate_detections.py
+++ b/tools/generate_detections.py
@@ -53,8 +53,13 @@ def extract_image_patch(image, bbox, patch_shape):
         bbox[0] -= (new_width - bbox[2]) / 2
         bbox[2] = new_width
 
-    # convert to top left, bottom right
-    bbox[2:] += bbox[:2]
+    # convert to top left, bottom right,
+    # box is (x, y, width, height). In order
+    # to get right bottom corner we need to
+    #  add width and height to x and y
+    # correspondingly and subtract 1
+    # as on line 67 for images rects
+    bbox[2:] += bbox[:2] - 1
     bbox = bbox.astype(np.int)
 
     # clip at image boundaries


### PR DESCRIPTION
The boxes are given in (top left x, top left y, width, height) format. In order to get bottom right corner we need to add width and height to x and y correspondingly and subtract 1.

On the line 62 in [`tools/generate_detections.py`](https://github.com/nwojke/deep_sort/blob/master/tools/generate_detections.py#L62) you treat image rect correctly by subtracting 1 from the image box, which is originally (0, 0, w, h) and after subtracting (0, 0, w - 1, h - 1).

```python
bbox[2:] = np.minimum(np.asarray(image.shape[:2][::-1]) - 1, bbox[2:])
```

however, you don't do it in other places across the repo, for example, on line 57 in the same file

```python
# convert to top left, bottom right
bbox[2:] += bbox[:2]
```

By not doing so, you get a pixel that is _diagonally_ to the bottom right corner. This minor inconsistency is really confusing.

There are 2 ways of how to resolve it:
1. Fix `rect` calculation across the codebase (**subtract 1 from other rects when converted to (left, top, right, bottom)**)
2. Make image `rect` consistent to other `rects` and **do not subtract 1 for the image right bottom corner**

I believe the first approach is more reasonable to take as it also fixes how `iou` is calculated.  Below is an example of how one can figure out the right bottom corner of a `rect`:

![Screenshot 2023-06-30 at 11 24 44](https://github.com/nwojke/deep_sort/assets/14966197/6440cfe0-5fdf-4454-b9cd-2e22549d2468)

This is not a critical issue and should not dramatically affect metrics though would be really nice to fix.