### PR TITLE
TrackerState initial value is set wrong for n_init==1

### DIFF
--- a/deep_sort/track.py
+++ b/deep_sort/track.py
@@ -72,13 +72,14 @@ class Track:
         self.age = 1
         self.time_since_update = 0
 
-        self.state = TrackState.Tentative
         self.features = []
         if feature is not None:
             self.features.append(feature)
 
         self._n_init = n_init
         self._max_age = max_age
+
+        self.state = TrackState.Tentative if self.hits < self._n_init else TrackState.Confirmed
 
     def to_tlwh(self):
         """Get current position in bounding box format `(top left x, top left y,


### PR DESCRIPTION
# Bug
In the boundary case of n_init==1, the current implementation fails to replicate the idea behind DeepSort.

Write now the default value of `TrackState` for a new `Track` instance is set to be equal to `Tentative `. This value is then updated upon the first match in the tracking. However, if n_init==1 and we have an immediate occlusion, as the track was marked tentative will never get to a match state and consequently, the TrackState will never change to `Confirmed`.

# Fix
in the constructor of `Track` assign initial value to `TrackState` according to `hits` and `n_init`.

```
self.state = TrackState.Tentative if self.hits < self._n_init else TrackState.Confirmed
```

# Compatibility
Adding this line does not effect the regular behaviour of the source code except for the boundary case discussed (n_init==1).

In case that n_init > 1, the expression simplifies to the following. Keep in mind that hits==1 in constructor.
```
self.state = TrackState.Tentative if 1 < self._n_init else TrackState.Confirmed
```
Or more simple as 
```
self.state = TrackState.Tentative if True else TrackState.Confirmed
```
With final value equaling to
```
self.state = TrackState.Tentative
```
which is the the current behaviour of the source code.