### PR TITLE
update deprecated code (linear_assignment and np's type)

### DIFF
--- a/application_util/preprocessing.py
+++ b/application_util/preprocessing.py
@@ -37,7 +37,7 @@ def non_max_suppression(boxes, max_bbox_overlap, scores=None):
     if len(boxes) == 0:
         return []
 
-    boxes = boxes.astype(np.float)
+    boxes = boxes.astype(np.float32)
     pick = []
 
     x1 = boxes[:, 0]

--- a/application_util/visualization.py
+++ b/application_util/visualization.py
@@ -128,7 +128,7 @@ class Visualization(object):
                 continue
             self.viewer.color = create_unique_color_uchar(track.track_id)
             self.viewer.rectangle(
-                *track.to_tlwh().astype(np.int), label=str(track.track_id))
+                *track.to_tlwh().astype(np.int32), label=str(track.track_id))
             # self.viewer.gaussian(track.mean[:2], track.covariance[:2, :2],
             #                      label="%d" % track.track_id)
 #

--- a/deep_sort/detection.py
+++ b/deep_sort/detection.py
@@ -27,7 +27,7 @@ class Detection(object):
     """
 
     def __init__(self, tlwh, confidence, feature):
-        self.tlwh = np.asarray(tlwh, dtype=np.float)
+        self.tlwh = np.asarray(tlwh, dtype=np.float32)
         self.confidence = float(confidence)
         self.feature = np.asarray(feature, dtype=np.float32)
 

--- a/deep_sort/linear_assignment.py
+++ b/deep_sort/linear_assignment.py
@@ -1,7 +1,8 @@
 # vim: expandtab:ts=4:sw=4
 from __future__ import absolute_import
 import numpy as np
-from sklearn.utils.linear_assignment_ import linear_assignment
+# from sklearn.utils.linear_assignment_ import linear_assignment
+from scipy.optimize import linear_sum_assignment
 from . import kalman_filter
 
 
@@ -55,16 +56,16 @@ def min_cost_matching(
     cost_matrix = distance_metric(
         tracks, detections, track_indices, detection_indices)
     cost_matrix[cost_matrix > max_distance] = max_distance + 1e-5
-    indices = linear_assignment(cost_matrix)
+    row_indices, col_indices = linear_sum_assignment(cost_matrix)
 
     matches, unmatched_tracks, unmatched_detections = [], [], []
     for col, detection_idx in enumerate(detection_indices):
-        if col not in indices[:, 1]:
+        if col not in col_indices:
             unmatched_detections.append(detection_idx)
     for row, track_idx in enumerate(track_indices):
-        if row not in indices[:, 0]:
+        if row not in row_indices:
             unmatched_tracks.append(track_idx)
-    for row, col in indices:
+    for row, col in zip(row_indices, col_indices):
         track_idx = track_indices[row]
         detection_idx = detection_indices[col]
         if cost_matrix[row, col] > max_distance:

--- a/deep_sort_app.py
+++ b/deep_sort_app.py
@@ -114,7 +114,7 @@ def create_detections(detection_mat, frame_idx, min_height=0):
         Returns detection responses at given frame index.
 
     """
-    frame_indices = detection_mat[:, 0].astype(np.int)
+    frame_indices = detection_mat[:, 0].astype(np.int64)
     mask = frame_indices == frame_idx
 
     detection_list = []
@@ -209,14 +209,15 @@ def run(sequence_dir, detection_file, output_file, min_confidence,
     f = open(output_file, 'w')
     for row in results:
         print('%d,%d,%.2f,%.2f,%.2f,%.2f,1,-1,-1,-1' % (
-            row[0], row[1], row[2], row[3], row[4], row[5]),file=f)
+            row[0], row[1], row[2], row[3], row[4], row[5]), file=f)
 
 
 def bool_string(input_string):
-    if input_string not in {"True","False"}:
+    if input_string not in {"True", "False"}:
         raise ValueError("Please Enter a valid Ture/False choice")
     else:
         return (input_string == "True")
+
 
 def parse_args():
     """ Parse command line arguments.


### PR DESCRIPTION
- the `linear_assignment` from `scikit-learn` is deprecated and has been removed, instead, now we use `linear_sum_assignment` from `scipy.optimize`. The two functions have slightly different return types and I did adjust the code so that it worked as it was.
- Many type casting in the project are deprecated (like `np.int` is no longer used, instead we use `int` or specify the precision like `np.int32`).

I've already tested it and now it runs perfectly without any errors.

![image](https://github.com/nwojke/deep_sort/assets/64354200/2b119b3a-e6c7-4359-92e5-8f93003373c1)
 